### PR TITLE
update include to include_tasks

### DIFF
--- a/prod-ansible-role/roles/apache/tasks/main.yml
+++ b/prod-ansible-role/roles/apache/tasks/main.yml
@@ -23,9 +23,9 @@
   user: name=apache groups={{ item }} state=present
   with_items: "{{ add_users }}"
 
-- include: set_apache.yml
-- include: set_apache-vhosts.yml
-- include: set_htaccess.yml
+- include_tasks: set_apache.yml
+- include_tasks: set_apache-vhosts.yml
+- include_tasks: set_htaccess.yml
 
 - name: Start httpd
   when:

--- a/prod-ansible-role/roles/concrete5/tasks/main.yml
+++ b/prod-ansible-role/roles/concrete5/tasks/main.yml
@@ -10,17 +10,17 @@
 #  include_vars: vars_nginx.yml
 #  when: webserver_handle=="nginx"
 
-- include: 10_upload_concrete5.yml
+- include_tasks: 10_upload_concrete5.yml
   when: c5_upload=="yes"
-- include: 20_install_concrete5.yml
+- include_tasks: 20_install_concrete5.yml
   when: c5_installation=="yes"
-- include: 25_directory_permission.yml
-- include: 30_upload_concrete5_config.yml
-- include: 40_restart_nginx.yml
+- include_tasks: 25_directory_permission.yml
+- include_tasks: 30_upload_concrete5_config.yml
+- include_tasks: 40_restart_nginx.yml
   when:
     - webserver_handle=="nginx"
     - isDocker=="no"
-- include: 40_restart_apache.yml
+- include_tasks: 40_restart_apache.yml
   when:
     - webserver_handle=="apache"
     - isDocker=="no"

--- a/prod-ansible-role/roles/concrete5_migration/tasks/main.yml
+++ b/prod-ansible-role/roles/concrete5_migration/tasks/main.yml
@@ -2,11 +2,11 @@
   stat: path={{vhost_docroot}}{{vhost_domain}}/application/config/database.php
   register: result
 
-- include: 10_upload_concrete5_backup.yml
-- include: 20_import_mysql.yml
-- include: 30_upload_concrete5_config.yml
-- include: 40_restart_nginx.yml
+- include_tasks: 10_upload_concrete5_backup.yml
+- include_tasks: 20_import_mysql.yml
+- include_tasks: 30_upload_concrete5_config.yml
+- include_tasks: 40_restart_nginx.yml
   when: webserver_handle=="nginx"
-- include: 40_restart_apache.yml
+- include_tasks: 40_restart_apache.yml
   when: webserver_handle=="apache"
-- include: 50_delete_backup.yml
+- include_tasks: 50_delete_backup.yml

--- a/prod-ansible-role/roles/default_setup/tasks/main.yml
+++ b/prod-ansible-role/roles/default_setup/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Set hostname to {{server_name}}
   hostname: name={{server_name}}
   when: isDocker=="no"
-- include: initialize_amazonlinux.yml
+- include_tasks: initialize_amazonlinux.yml
   when: aws_awslinux in ["1", "2"]
 - name: Set locale to /etc/sysconfig/i18n
   when: centos_version=="6"
@@ -21,26 +21,26 @@
   timezone:
     name: "{{zone}}"
   when: isDocker=="no"
-- include: install_repo_centos6.yml
+- include_tasks: install_repo_centos6.yml
   when: centos_version=="6" and aws_awslinux=="no"
-- include: install_repo_centos7.yml
+- include_tasks: install_repo_centos7.yml
   when: centos_version=="7" and aws_awslinux=="no"
-- include: install_repo_amazonlinux2.yml
+- include_tasks: install_repo_amazonlinux2.yml
   when: aws_awslinux=="2"
 - name: Apply All Updates
   yum:
     name: '*'
     state: latest
-- include: install_util.yml
-- include: install_extra.yml
-- include: initialize_etckeeper.yml
-- include: initialize_logrorate.yml
-- include: initialize_firewall_centos7.yml
+- include_tasks: install_util.yml
+- include_tasks: install_extra.yml
+- include_tasks: initialize_etckeeper.yml
+- include_tasks: initialize_logrorate.yml
+- include_tasks: initialize_firewall_centos7.yml
   when:
     - centos_version=="7" and aws_awslinux=="no"
     - centos_firewall_enable=="yes"
     - isDocker=="no"
-- include: initialize_swapfile.yml
+- include_tasks: initialize_swapfile.yml
   when:
     - centos_version=="7" or aws_awslinux=="2"
     - isDocker=="no"

--- a/prod-ansible-role/roles/mysql_server/tasks/main.yml
+++ b/prod-ansible-role/roles/mysql_server/tasks/main.yml
@@ -34,7 +34,7 @@
     - isDocker=="no"
   systemd: name=mysqld state=started enabled=yes
 
-- include: set_mysqlroot.yml
+- include_tasks: set_mysqlroot.yml
   when: isDocker=="no"
 
 - name: Replace MySQL Config to disable performance schema

--- a/prod-ansible-role/roles/nginx/tasks/main.yml
+++ b/prod-ansible-role/roles/nginx/tasks/main.yml
@@ -24,8 +24,8 @@
     - centos_version=="7"
     # - NginxPHPResult.changed == True
     - isDocker=="no"
-- include: set_nginx.yml
-- include: set_nginx-vhost.yml
+- include_tasks: set_nginx.yml
+- include_tasks: set_nginx-vhost.yml
 
 - name: Chenge Directory Permission -  Nginx Log
   file: path="/var/log/nginx/" state=directory recurse=yes mode=0755

--- a/prod-ansible-role/roles/php/tasks/main.yml
+++ b/prod-ansible-role/roles/php/tasks/main.yml
@@ -227,12 +227,12 @@
     - centos_version=="7"
     - NginxPHPResult.changed == True
     - isDocker=="no"
-- include: set_php-fpm.yml
+- include_tasks: set_php-fpm.yml
   when: aws_awslinux !="1"
-- include: set_php-fpm-al-1.yml
+- include_tasks: set_php-fpm-al-1.yml
   when: aws_awslinux=="1"
 
-- include: set_php.yml
+- include_tasks: set_php.yml
 
 - name: Chenge Directory Permission - PHP-fpm
   file: path="/var/log/php-fpm/" state=directory recurse=yes mode=0755


### PR DESCRIPTION

```
TASK [default_setup : Set hostname to cuho-legacy.c5j.me] ********************************************************************************************************
changed: [35.79.65.117]
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```